### PR TITLE
change isAlive(), which was removed in python 3.9,  to is_alive()

### DIFF
--- a/src/bin/web_ping.py
+++ b/src/bin/web_ping.py
@@ -811,7 +811,7 @@ class WebPing(ModularInput):
         for thread_stanza in list(threads):
 
             # If the thread isn't alive, prune it
-            if not threads[thread_stanza].isAlive():
+            if not threads[thread_stanza].is_alive():
                 removed_threads = removed_threads + 1
                 self.logger.debug("Removing inactive thread for stanza=%s, thread_count=%i", thread_stanza, len(threads))
                 del threads[thread_stanza]


### PR DESCRIPTION
Monitoring was broken after updating splunk. Searching `index=_internal (sourcetype=web_availability_modular_input ERROR) ` revealed error due to isAlive() call, which was removed in Python 3.9
I edited my local copy of $SPLUNK_HOME/etc/apps/website_monitoring/bin/web_ping.py to change isAlive() to is_alive(), deactivated and reactivated the website monitoring app and it was functional again.